### PR TITLE
Add a step to run PSScriptAnalyzer

### DIFF
--- a/Module/plasterManifest.xml
+++ b/Module/plasterManifest.xml
@@ -71,6 +71,7 @@
     <requireModule name="Pester" condition="$PLASTER_PARAM_Options -contains 'Pester'" minimumVersion="3.4.0" message="Without Pester, you will not be able to run the provided Pester test to validate your module manifest file.`nWithout version 3.4.0, VS Code will not display Pester warnings and errors in the Problems panel."/>
     <requireModule name="InvokeBuild" condition="$PLASTER_PARAM_Options -contains 'InvokeBuild'" minimumVersion="3.6.5" message="Without InvokeBuild, you will not be able to build the module and create a production version."/>
     <requireModule name="ModuleBuilder" condition="$PLASTER_PARAM_Options -contains 'InvokeBuild'" minimumVersion="1.0.0" message="Without ModuleBuilder, you will not be able to build the module and create a production version."/>
+    <requireModule name="PSScriptAnalyzer" condition="$PLASTER_PARAM_Options -contains 'InvokeBuild'" minimumVersion="1.0.1" message="Without PSScriptAnalyzer, you will not be able to do static code analysis."/>
     <!-- Summary messages -->
     <message>&#10;&#10;Your new PowerShell module project '$PLASTER_PARAM_ModuleName' has been created.&#10;&#10;</message>
     <message condition="$PLASTER_PARAM_Options -contains 'Pester'">&#10;A Pester test has been created to validate the module's manifest file. Add additional tests to the test directory.</message>

--- a/Module/source/Readme.md
+++ b/Module/source/Readme.md
@@ -20,6 +20,7 @@ To build the module, make sure you have the following pre-req modules:
 - InvokeBuild (Required Version 3.2.1)
 - PowerShellGet (Required Version 1.6.0)
 - ModuleBuilder (Required Version 1.0.0)
+- PSScriptAnalyzer (Required Version 1.0.1)
 
 Start the build by running the following command from the project root:
 


### PR DESCRIPTION
Run PSScriptAnalyzer after cleaning but before testing. If it reports any errors, the build will fail. If it reports any warning, the build will be allowed to continue but it will be flagged as a build warning.